### PR TITLE
Deploy StylusDeployer in start-up

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts"]
+	path = contracts
+	url = https://github.com/OffchainLabs/nitro-contracts.git

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To use the script, follow these steps:
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/OffchainLabs/nitro-devnode.git
+git clone --recurse-submodules https://github.com/OffchainLabs/nitro-devnode.git
 cd nitro-devnode
 ```
 


### PR DESCRIPTION
The StylusDeployer contract is necessary for deploying Stylus contracts that use constructors.
This PR is related to: https://github.com/OffchainLabs/cargo-stylus/pull/131