### PR TITLE
added --broadcast to enable broadcasting during deployment

### DIFF
--- a/run-dev-node.sh
+++ b/run-dev-node.sh
@@ -104,6 +104,7 @@ echo "Cache Manager deployed and registered successfully"
 # Deploy StylusDeployer
 deployer_output=$(forge create --private-key 0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 \
     --out ./contracts/out  --cache-path ./contracts/cache -r http://127.0.0.1:8547 \
+    --broadcast \
     ./contracts/src/stylus/StylusDeployer.sol:StylusDeployer)
 deployer_address=$(echo "$deployer_output" | awk '/Deployed to/ {print $3}')
 if [[ -z "$deployer_address" ]]; then


### PR DESCRIPTION
The current script is giving this error:

```
Starting Nitro dev node...
Waiting for the Nitro node to initialize...
WARN [03-22|04:51:17.733] Chain info field parent-chain-is-arbitrum is missing, in the future this will be required chainId=412,346 parentChainId=0
WARN [03-22|04:51:17.744] track-block-metadata-from is set but blockMetadata fetcher is not enabled
INFO [03-22|04:51:17.748] created jwt file                         filename=/home/user/.arbitrum/jwtsecret
INFO [03-22|04:51:17.748] Running Arbitrum nitro node              revision=v3.5.3-0a9c975 vcs.time=2025-03-10T09:20:36-07:00
WARN [03-22|04:51:17.748] Sequencer node's track-block-metadata-from is set but timeboost is not enabled
INFO [03-22|04:51:17.749] Defaulting to pebble as the backing database
INFO [03-22|04:51:17.749] Allocated cache and file handles         database=/tmp/dev-test/nitro/l2chaindata cache=16.00MiB handles=16
INFO [03-22|04:51:17.749] Defaulting to pebble as the backing database
INFO [03-22|04:51:17.749] Allocated cache and file handles         database=/tmp/dev-test/nitro/l2chaindata cache=2.00GiB handles=512
INFO [03-22|04:51:17.776] Opened ancient database                  database=/tmp/dev-test/nitro/l2chaindata/ancient/chain readonly=false
INFO [03-22|04:51:17.777] Defaulting to pebble as the backing database
INFO [03-22|04:51:17.777] Allocated cache and file handles         database=/tmp/dev-test/nitro/wasm cache=2.00GiB handles=512
ERROR[03-22|04:51:17.777] Head block is not reachable
INFO [03-22|04:51:17.783] State scheme set by user                 scheme=hash
INFO [03-22|04:51:17.783] Setting codehash position in rebuilding of wasm store to done
INFO [03-22|04:51:17.783] Initializing                             ancients=0 genesisBlockNr=0
WARN [03-22|04:51:17.783] Created fake init message as L1Reader is disabled and serialized chain config from init message is not available json="{\"chainId\":412346,\"homesteadBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"berlinBlock\":0,\"londonBlock\":0,\"clique\":{\"period\":0,\"epoch\":0},\"arbitrum\":{\"EnableArbOS\":true,\"AllowDebugPrecompiles\":true,\"DataAvailabilityCommittee\":false,\"InitialArbOSVersion\":32,\"InitialChainOwner\":\"0x0000000000000000000000000000000000000000\",\"GenesisBlockNum\":0}}"
ERROR[03-22|04:51:17.783] Zero state root hash!
ERROR[03-22|04:51:17.783] Zero state root hash!
INFO [03-22|04:51:17.783] addresss table import complete
INFO [03-22|04:51:17.783] retryables import complete
INFO [03-22|04:51:17.784] Persisted trie from memory database      nodes=85 flushnodes=0 size=9.62KiB flushsize=0.00B time="209.913µs" flushtime=0s gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
INFO [03-22|04:51:17.784] Persisted trie from memory database      nodes=4  flushnodes=0 size=806.00B flushsize=0.00B time="13.25µs"   flushtime=0s gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
INFO [03-22|04:51:17.784] wrote genesis block                      number=0 hash=28cc69..d917f7
INFO [03-22|04:51:17.784] 
INFO [03-22|04:51:17.784] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [03-22|04:51:17.784] Chain ID:  412346 (unknown)
INFO [03-22|04:51:17.784] Consensus: Clique (proof-of-authority)
INFO [03-22|04:51:17.784] 
INFO [03-22|04:51:17.784] Pre-Merge hard forks (block based):
INFO [03-22|04:51:17.784]  - Homestead:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md)
INFO [03-22|04:51:17.784]  - Tangerine Whistle (EIP 150): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md)
INFO [03-22|04:51:17.784]  - Spurious Dragon/1 (EIP 155): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [03-22|04:51:17.784]  - Spurious Dragon/2 (EIP 158): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [03-22|04:51:17.784]  - Byzantium:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md)
INFO [03-22|04:51:17.784]  - Constantinople:              #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md)
INFO [03-22|04:51:17.784]  - Petersburg:                  #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md)
INFO [03-22|04:51:17.784]  - Istanbul:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md)
INFO [03-22|04:51:17.784]  - Muir Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md)
INFO [03-22|04:51:17.784]  - Berlin:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)
INFO [03-22|04:51:17.784]  - London:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)
INFO [03-22|04:51:17.784] 
INFO [03-22|04:51:17.784] The Merge is not yet available for this network!
INFO [03-22|04:51:17.785]  - Hard-fork specification: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md
INFO [03-22|04:51:17.785] 
INFO [03-22|04:51:17.785] Post-Merge hard forks (timestamp based):
INFO [03-22|04:51:17.785] 
INFO [03-22|04:51:17.785] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [03-22|04:51:17.785] 
INFO [03-22|04:51:17.785] Loaded most recent local block           number=0 hash=28cc69..d917f7 td=1 age=56y1w2d
WARN [03-22|04:51:17.785] Failed to load snapshot                  err="missing or corrupted snapshot"
INFO [03-22|04:51:17.787] Rebuilding state snapshot
INFO [03-22|04:51:17.787] Initialized transaction indexer          range="last 126230400 blocks"
INFO [03-22|04:51:17.787] Resuming state snapshot generation       root=9a03fc..f792bc accounts=0 slots=0 storage=0.00B dangling=0 elapsed="156.456µs"
INFO [03-22|04:51:17.787] Setting rebuilding of wasm store to done
INFO [03-22|04:51:17.787] Defaulting to pebble as the backing database
INFO [03-22|04:51:17.788] Allocated cache and file handles         database=/tmp/dev-test/nitro/arbitrumdata cache=16.00MiB handles=16
INFO [03-22|04:51:17.788] Generated state snapshot                 accounts=18 slots=45 storage=4.71KiB dangling=0 elapsed=1.473ms
WARN [03-22|04:51:17.795] sequencer enabled without l1 client
INFO [03-22|04:51:17.796] Starting peer-to-peer node               instance=nitro/v3.5.3-0a9c975/linux-arm64/go1.23.1
WARN [03-22|04:51:17.796] P2P server will be useless, neither dialing nor listening
INFO [03-22|04:51:17.803] HTTP server started                      endpoint=[::]:8547 auth=false prefix= cors= vhosts=localhost
INFO [03-22|04:51:17.804] New local node record                    seq=1,742,619,077,803 id=a1a9191cebb8a296 ip=127.0.0.1 udp=0 tcp=0
INFO [03-22|04:51:17.804] Started P2P networking                   self=enode://f46bb4c338efc1e816638dd43e936a3133d249289c91aaa3cfd9ce7ebbed8707d67799eb3a52edf8ff0d43e4814f6775ad810b214127b126fa65cbe1a6474882@127.0.0.1:0
Nitro node is running!
Setting chain owner to pre-funded dev account...
INFO [03-22|04:51:17.952] Submitted transaction                    hash=0x7365c71c3b60e635f0255be8a515b48e68a547090a7d62cf396dc0571d1c6e80 from=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E nonce=0 recipient=0x00000000000000000000000000000000000000ff value=0
INFO [03-22|04:51:17.952] Indexed transactions                     blocks=2 txs=2 tail=0 elapsed="101.374µs"

blockHash            0xd86a23ca600024048d936ad60302e8124c3b2fe8a6ca1c2ddef382b91534ecf0
blockNumber          1
contractAddress      
cumulativeGasUsed    958664
effectiveGasPrice    100000000
from                 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E
gasUsed              958664
logs                 []
logsBloom            0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
root                 
status               1 (success)
transactionHash      0x7365c71c3b60e635f0255be8a515b48e68a547090a7d62cf396dc0571d1c6e80
transactionIndex     1
type                 2
blobGasPrice         
blobGasUsed          
authorizationList    
to                   0x00000000000000000000000000000000000000ff
gasUsedForL1         936000
l1BlockNumber        0
timeboosted          false

Deploying Cache Manager contract...
INFO [03-22|04:51:18.058] Submitted contract creation              hash=0xc1131b070db52dfe664e10f3b02261c7476424050dc0095e04f8447ae93c81d6 from=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E nonce=1 contract=0x11B57FE348584f042E436c6Bf7c3c3deF171de49 value=0
Cache Manager contract deployed at address: 0x11B57FE348584f042E436c6Bf7c3c3deF171de49
Registering Cache Manager contract as a WASM cache manager...
INFO [03-22|04:51:18.311] Submitted transaction                    hash=0x5084e9fd6fe32ca14b701cab39293be2d9dbd108084cd68390cbc0609e39c089 from=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E nonce=2 recipient=0x0000000000000000000000000000000000000070 value=0
Cache Manager deployed and registered successfully
INFO [03-22|04:51:18.563] Submitted contract creation              hash=0x3a15c9243b41c7da840e6dc3eeba6d66e41d0b085b92f04325291b27a2eddf09 from=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E nonce=3 contract=0xA6E41fFD769491a42A6e5Ce453259b93983a22EF value=0
StylusDeployer deployed at address: 0xA6E41fFD769491a42A6e5Ce453259b93983a22EF
Nitro node is running...
^C%                                                                                                                            
```

This PR attempts to solve this error by adding --broadcast flag to the script which should solve the error in:
line 107
```
# Deploy StylusDeployer
deployer_output=$(forge create --private-key 0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 \
    --out ./contracts/out  --cache-path ./contracts/cache -r http://127.0.0.1:8547 \
    --broadcast \
    ./contracts/src/stylus/StylusDeployer.sol:StylusDeployer)
```