### PR TITLE
Update docker image specifiers to be override-able through env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,30 @@ The script will:
 - Deploy the Stylus `Cache Manager` contract on the local Nitro network.
 - Register the `Cache Manager` contract as a WASM cache manager.
 
+### Environment Variables
+
+You can override the default behavior of the script using environment variables:
+
+- **`NITRO_NODE_VERSION`**  
+  Version tag of the Nitro node to run.  
+  Default: `v3.7.1-926f1ab`
+
+- **`TARGET_IMAGE`**  
+  Full Docker image reference for the Nitro node.  
+  Default: `offchainlabs/nitro-node:${NITRO_NODE_VERSION}`
+
+#### Examples
+
+Use a different Nitro node version:
+```bash
+NITRO_NODE_VERSION=v3.8.0 ./run-dev-node.sh
+```
+
+Use a custom Docker image:
+```bash
+TARGET_IMAGE=myrepo/custom-nitro:latest ./run-dev-node.sh
+```
+
 ## Note on `--dev` mode
 
 The script starts the Nitro node in `--dev` mode, which does not persist chain data. Each time you restart the node, the chain state resets. This is suitable for testing and development purposes, but for persistent chain data, consider using a full node setup instead of `--dev`.

--- a/run-dev-node.sh
+++ b/run-dev-node.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-NITRO_NODE_VERSION="v3.7.1-926f1ab"  # <-- only update this when you need a new version
-TARGET_IMAGE="offchainlabs/nitro-node:${NITRO_NODE_VERSION}"
+# Allow overrides from the environment or CLI
+NITRO_NODE_VERSION="${NITRO_NODE_VERSION:-v3.7.1-926f1ab}"
+TARGET_IMAGE="${TARGET_IMAGE:-offchainlabs/nitro-node:${NITRO_NODE_VERSION}}"
 
 RPC=http://127.0.0.1:8547
 PRIVATE_KEY=0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659


### PR DESCRIPTION
I am working on NIT-3596 which is running execution-spec-tests in CI

The current setup for running execution spec tests is

- run dev node
- run execution spec tests against dev node

I want to run a docker image of master, instead of the static one here. So being able to override these variables would be very nice