### PR TITLE
Properly shutdown docker contrainers, when shutting down nitro-devnode script

### DIFF
--- a/run-dev-node.sh
+++ b/run-dev-node.sh
@@ -43,9 +43,6 @@ docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
 echo "Starting Nitro dev node..."
 docker run --rm --name "${CONTAINER_NAME}" -p 8547:8547 "${TARGET_IMAGE}" --dev --http.addr 0.0.0.0 --http.api=net,web3,eth,debug $EXTRA_ARGS &
 
-# Kill background processes when exiting
-trap 'kill $(jobs -p) 2>/dev/null' EXIT
-
 # Wait for the node to initialize
 echo "Waiting for the Nitro node to initialize..."
 

--- a/run-dev-node.sh
+++ b/run-dev-node.sh
@@ -17,6 +17,8 @@ EXTRA_ARGS=""
 cleanup() {
   echo "Shutting down Docker container '${CONTAINER_NAME}'..."
   docker stop -t 30 "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+
+  # Force remove the container if shutdown didn't work within the timeout period
   docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
 }
 trap cleanup INT TERM EXIT


### PR DESCRIPTION
fixes NIT-4016

# solution

Add a bash trap which waits for a exit signal, then runs a cleanup function which shuts down and cleans up the deployed nitro-devnode